### PR TITLE
Fix recursion template config

### DIFF
--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -18,8 +18,9 @@ options {
     // to talk to, you may need to fix the firewall to allow multiple
     // ports to talk.  See http://www.kb.cert.org/vuls/id/800113
 
-    recursion yes;
-    allow-query { trusted; };
+    recursion no;
+    allow-query { any; };
+    allow-recursion { trusted; };
         
 {% if bind_forwarders is defined and bind_forwarders.0 is defined %}
     forwarders {


### PR DESCRIPTION
Use `allow-recursion` instead of `allow-query`.  This allows the server
to correctly filter trusted hosts to allow recursion, but allow any
hosts to query for authoritative zones.
