### PR TITLE
Added CentOS/RHEL and named-chroot support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,3 +45,7 @@ bind_dns64_clients: []
 
 # Additional ip's that are allowd to do axfr queries
 bind_allow_transfer: []
+
+bind_chroot: False
+
+bind_config_file: "{{bind_config_dir}}/named.conf"

--- a/tasks/config.el.yml
+++ b/tasks/config.el.yml
@@ -1,0 +1,89 @@
+---
+# tasks file for netzwirt.bind
+# configuration
+
+
+- name: get root.db file from internic.net
+  get_url:
+    url=ftp://ftp.rs.internic.net/domain/db.cache
+    dest={{bind_config_dir}}/db.root
+    url_password=ftp
+    url_username=ftp
+
+
+- name: get bind.keys from isc.org
+  get_url:
+    url=http://ftp.isc.org/isc/bind9/keys/9.8/bind.keys.v9_8
+    dest={{bind_config_dir}}/bind.keys
+    url_password=ftp
+    url_username=ftp
+
+
+- name: create db-files
+  copy:
+    dest={{bind_config_dir}}/{{ item }}
+    src={{ item }}
+    owner=root
+    group={{ bind_group }}
+    mode=0640
+  notify: [restart bind]
+  with_items:
+  - db.0
+  - db.127
+  - db.255
+  - db.empty
+  - db.local
+
+- name: create named.conf
+  template:
+    dest={{bind_config_file}}
+    src={{ item }}.j2
+    owner=root
+    group={{ bind_group }}
+    mode=0640
+  notify: [restart bind]
+  with_items:
+  - named.conf
+
+- name: create config-files
+  template:
+    dest={{bind_config_dir}}/{{ item }}
+    src={{ item }}.j2
+    owner=root
+    group={{ bind_group }}
+    mode=0640
+  notify: [restart bind]
+  with_items:
+  - named.conf.default-zones
+  - named.conf.local
+  - named.conf.options
+  - zones.rfc1918
+
+
+- name: create rndc key
+  shell: rndc-confgen -a -r /dev/urandom
+         -t {{bind_config_dir}}
+         -c {{bind_config_dir}}/rndc.key 2>/dev/null
+         ; chmod 0640 {{bind_config_dir}}/rndc.key ; exit 0
+    creates={{bind_config_dir}}/rndc.key
+    executable=/bin/bash
+  notify: [restart bind]
+
+
+- name: copy master zone files
+  copy:
+    src={{bind_lookup_zones}}/db.{{item.key}}
+    dest={{bind_cache_dir}}/db.{{item.key}}
+    owner={{bind_user}}
+    group={{bind_group}}
+  notify: [restart bind]
+  when: item.value.type == "master"
+  with_dict: bind_zones
+
+- name: build slave zones from master
+  template:
+    src=build.slave.j2
+    dest="{{bind_config_dir}}/named.conf.local.slave-{{item.master}}-{{item.limit_to|default(['all'])|join('-')}}"
+  notify: [restart bind]
+  when: bind_create_slave_from_master is defined and bind_create_slave_from_master.0 is defined
+  with_items: bind_create_slave_from_master

--- a/tasks/install.yum.yml
+++ b/tasks/install.yum.yml
@@ -1,0 +1,6 @@
+---
+# tasks file for bind-chroot
+- name: install required bind-chroot package
+  yum: name={{item}}
+  with_items:
+    - bind-chroot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,14 +2,14 @@
 # tasks file for netzwirt.bind
 
 - name: create group for bind
-  group: 
+  group:
     name: "{{ bind_group }}"
     system: yes
     state: present
 
 
 - name: create user for bind
-  user: 
+  user:
     name: "{{ bind_user }}"
     comment: "bind-user"
     group: "{{ bind_group }}"
@@ -22,12 +22,19 @@
   include: install.apt.yml
   when: ansible_os_family == 'Debian'
 
+- name: installing packages with yum
+  include: install.yum.yml
+  when: ansible_os_family == 'RedHat'
+
 
 - include: config.yml
+  when: ansible_os_family == 'Debian'
 
+- include: config.el.yml
+  when: ansible_os_family == 'RedHat'
 
 - name: ensure bind is started
-  service: 
+  service:
     name: "{{ bind_service_name }}"
-    state: started 
+    state: started
     enabled: yes

--- a/templates/named.conf.local.j2
+++ b/templates/named.conf.local.j2
@@ -9,18 +9,22 @@ include "{{bind_config_dir}}/zones.rfc1918";
 {% for key, zone in bind_zones.iteritems() %}
 zone "{{key}}" {
     type {{zone.type|default('master')}}; # zone file type
+{% if zone.type is not defined or zone.type is defined and zone.type != 'forward' %}
     file "{{bind_cache_dir}}/db.{{key}}"; # zone file path
+{% endif %}
 {% if zone.secondary is defined and zone.secondary.0 is defined %}
 {% if zone.type is defined and zone.type == 'slave' %}
     # masters ip adresses
     masters { 
+{% elif zone.type is defined and zone.type == 'forward' %}
+    forwarders {
 {% else %}
     # secondary ip adresses
     allow-transfer { 
+{% for secondary in bind_allow_transfer %}
+        {{secondary}};{% endfor %}
 {% endif %}
 {% for secondary in zone.secondary %}
-        {{secondary}};{% endfor %}
-{% for secondary in bind_allow_transfer %}
         {{secondary}};{% endfor %}
     }; {% endif %}       
 };


### PR DESCRIPTION
Example playbook variables for using chroot on RHEL/CentOS 7 are as follows:
`
          bind_config_dir: '/var/named/chroot/etc/named',
          bind_config_file: '/var/named/chroot/etc/named.conf',
          bind_service_name: 'named-chroot',
`
