### PR TITLE
Add support for statistics-channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ Create dns64 clients list in named.conf.options
 bind_dns64_clients:
   - v6localhost
 ```
+
+## statistics-channels
+
+Enable the use of [statistics-channels](https://kb.isc.org/docs/aa-00769). This allows for monitoring via systems like the [Prometheus bind_exporter](https://github.com/prometheus-community/bind_exporter).
+
+```yaml
+bind_statistics_channels:
+  - inet: 127.0.0.1
+    port: 8053
+    allow:
+      - 127.0.0.1
+```
+
 ## Zones definition
 
 Zones are defined as dict. The key is used as domain name.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ bind_create_slave_from_master: []
 # as dict
 bind_acls: {}
 
+# create statistics-channels for monitoring.
+bind_statistics_channels: []
+
 # List clients for dns64 in named.conf.options
 bind_dns64_clients: []
 

--- a/templates/named.conf.options.j2
+++ b/templates/named.conf.options.j2
@@ -18,7 +18,18 @@ acl trusted {
     localnets;
 };
 
+{% if bind_statistics_channels | length %}
+statistics-channels {
+{% for channel in bind_statistics_channels %}
+    inet {{ channel.inet }} port {{ channel.port }} allow {
+{% for allow in channel.allow %}
+        {{ allow }};
+{% endfor %}
+    };
+{% endfor %}
+};
 
+{% endif %}
 options {
 
     directory "{{bind_cache_dir}}";


### PR DESCRIPTION
Add to options template to enable statistics-channels[0].

This allows for using the Prometheus bind_exporter[1].

[0]: https://kb.isc.org/docs/aa-00769
[1]: https://github.com/prometheus-community/bind_exporter

Signed-off-by: Ben Kochie <superq@gmail.com>